### PR TITLE
DOC: adjusted to fit more general case n != m

### DIFF
--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -36,8 +36,8 @@ namespace itk
  *
  * \par Overview
  * This filter has two calculation modes.  The first (default) mode calculates
- * gradient magnitude as the difference between the largest two eigenvalues in a
- * principle component analysis of the partial derivatives [1].  The
+ * gradient magnitude as the difference between the largest two singular values in a
+ * singular value decomposition (SVD) of the partial derivatives [1].  The
  * gradient is then based on the direction of maximal change, and is a
  * characterization of how "elongated" the point-spread of the analysis is
  * found to be.

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -65,8 +65,7 @@ namespace itk
  *
  * The second template parameter, TRealType, can be optionally specified to define the
  * scalar numerical type used in calculations.  This is the component type of
- * the output image, which will be of itk::Vector<TRealType, N>, where N is the
- * number of channels in the multiple component input image.  The default type
+ * the output image.  The default type
  * of TRealType is float.  For extra precision, you may safely change this
  * parameter to double.
  *
@@ -75,7 +74,7 @@ namespace itk
  * it is not necessary (or advisable) to set this parameter explicitly.  Given
  * an M-channel input image with dimensionality N, and a numerical type
  * specified as TRealType, the output image will be of type
- * itk::Image<itk::Vector<TRealType, M>, N>.
+ * itk::Image<TRealType, N>.
  *
  * \par Filter Parameters
  * The methods Set/GetUsePrincipleComponents and


### PR DESCRIPTION
To my understanding eigenvalues and PCA are the special case for a m×n matrix with n = m, i.e. a square matrix. However, the first order derivative (Jacobian) can be a non-square matrix, i.e. m ≠ n, in case the image dimension does not equal the number of vector components (channels).
The PR is meant as a discussion initiation, as I am not an expert in this field and stumbled upon this while trying to understand the math behind this filter.
